### PR TITLE
Namespaces

### DIFF
--- a/lib/src/models.dart
+++ b/lib/src/models.dart
@@ -1,4 +1,4 @@
-library mmodels;
+library apk_parser.mmodels;
 
 /**
  * http://developer.android.com/guide/topics/manifest/manifest-element.html

--- a/lib/src/parser.dart
+++ b/lib/src/parser.dart
@@ -1,4 +1,4 @@
-library parser;
+library apk_parser.parser;
 
 /**
  * Extract android manifest from apk files. Original implementation in Java can

--- a/lib/src/processors.dart
+++ b/lib/src/processors.dart
@@ -1,4 +1,4 @@
-library processors;
+library apk_parser.processors;
 
 import 'package:xmlstream/xmlstream.dart';
 import 'package:apk_parser/apk_parser.dart';


### PR DESCRIPTION
It's a good idea to prefix your library names with something unique for your package. This makes it so if I wanted to reflect into your library, I could do it easier. It also makes dart2js happier :)
